### PR TITLE
Add JSON dependency to gemspec

### DIFF
--- a/mixpanel_client.gemspec
+++ b/mixpanel_client.gemspec
@@ -18,7 +18,8 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ['lib']
-
+  
+  s.add_dependency('json', "~> 1.5.1")
   s.add_development_dependency('rspec',     '>=2.5.0')
   s.add_development_dependency('webmock',   '>=1.6.2')
   s.add_development_dependency('metric_fu', '>=2.1.1')


### PR DESCRIPTION
mixpanel_client requires 'json', but it isn't listed in the gemspec.
