### PR TITLE
update BASE_URI to use https

### DIFF
--- a/lib/mixpanel/client.rb
+++ b/lib/mixpanel/client.rb
@@ -9,7 +9,7 @@
 module Mixpanel
   # Return metrics from Mixpanel Data API
   class Client
-    BASE_URI = 'http://mixpanel.com/api/2.0'
+    BASE_URI = 'https://mixpanel.com/api/2.0'
 
     attr_reader   :uri
     attr_accessor :api_key, :api_secret


### PR DESCRIPTION
mixpanel deployed a change that redirects all http traffic to https and
there is a bug in open-uri that fails on this:
http://bugs.ruby-lang.org/issues/5950
