### PR TITLE
Add an optional hash attribute to each MixpanelClient instance

### DIFF
--- a/lib/mixpanel/client.rb
+++ b/lib/mixpanel/client.rb
@@ -13,7 +13,7 @@ module Mixpanel
     DATA_URI = 'https://data.mixpanel.com/api/2.0'
 
     attr_reader   :uri
-    attr_accessor :api_key, :api_secret
+    attr_accessor :api_key, :api_secret, :options
 
     # Available options for a Mixpanel API request
     OPTIONS = [:resource, :event, :events, :funnel_id, :name, :type, :unit, :interval, :limit, 
@@ -31,13 +31,16 @@ module Mixpanel
     # Configure the client
     #
     # @example
-    #   config = {'api_key' => '123', 'api_secret' => '456'}
+    #   config = {:api_key => '123', :api_secret => '456',
+    #             :options => {:username => 'Bill'}}
     #   client = Mixpanel::Client.new(config)
     #
     # @param [Hash] config consisting of an 'api_key' and an 'api_secret'
-    def initialize(config)
-      @api_key    = config['api_key']
-      @api_secret = config['api_secret']
+    # Additional options may be added to an options hash for client-specific data
+    def initialize(config, options = {})
+      @options    = config[:options]
+      @api_key    = config[:api_key]
+      @api_secret = config[:api_secret]
     end
 
     # Return mixpanel data as a JSON object or CSV string


### PR DESCRIPTION
In our Rails app, each User instance has it's own instance of MixpanelClient, because we use the Data Export API to give our Users data specific to them.

So, our request looked something like this:

``` ruby
result = client.request do
      ...
      on 'properties["user"]'
end
```

So, that would pull down the data for EVERY user. Obviously, this is pretty inefficient if you've got a ton of users, and we wanted to pull down just one user's mixpanel events. 

So, my solution was to add an optional hash to the MixpanelClient when it's instantiated, which can then be accessed inside of its request blocks:

``` ruby
result = client.request do
      ...
      on 'properties["user"]'
      where %{"#{self.options[:username]}" == properties["user"]}
end
```

I'm pretty new to Ruby and contributing to open source, so if there's a better way of doing this, please let me know! The syntax (especially self.options[:username] seems kind of ugly anyway.
