### PR TITLE
Added "length" property used by funnels endpoint

### DIFF
--- a/lib/mixpanel/client.rb
+++ b/lib/mixpanel/client.rb
@@ -16,7 +16,7 @@ module Mixpanel
     attr_accessor :api_key, :api_secret
 
     # Available options for a Mixpanel API request
-    OPTIONS = [:resource, :event, :events, :funnel_id, :name, :type, :unit, :interval, :limit, 
+    OPTIONS = [:resource, :event, :events, :funnel_id, :name, :type, :unit, :interval, :length, :limit, 
                :format, :bucket, :values, :from_date, :to_date, :on, :where, :buckets, :timezone]
 
     # Dynamically define accessor methods for each option

--- a/spec/mixpanel_client/mixpanel_client_spec.rb
+++ b/spec/mixpanel_client/mixpanel_client_spec.rb
@@ -95,6 +95,7 @@ describe Mixpanel::Client do
         type      'A'
         unit      'hour'
         interval  24
+        length    1
         limit     5
         format    'csv'
         bucket    'list'


### PR DESCRIPTION
As documented here:

https://mixpanel.com/docs/api-documentation/data-export-api#funnels-default
