### PR TITLE
Adapt the manual test to v3.0 interface

### DIFF
--- a/manual_test/basic.rb
+++ b/manual_test/basic.rb
@@ -6,14 +6,13 @@ require 'yaml'
 
 config = YAML.load_file(File.dirname(__FILE__) + '/../config/mixpanel.yml')['mixpanel']
 
-client = Mixpanel::Client.new(config)
+client = Mixpanel::Client.new({api_key: config['api_key'], api_secret: config['api_secret']})
 
-data = client.request do
-  resource 'events/properties'
-  event    '["test-event"]'
-  type     'general'
-  unit     'hour'
-  name     'test'
-end
+data = client.request('events/properties', {
+  event:    '["test-event"]',
+  type:     'general',
+  unit:     'hour',
+  name:     'test'
+})
 
 puts data.inspect


### PR DESCRIPTION
I made the `manual_test/basic.rb` to accept two large changes:
- the args of Mixpanel::Client#request
- keys of the arg of Mixpanel::Client#new are symbols, not strings
