### PR TITLE
Avoid overriding the arg of client.request

### DIFF
--- a/lib/mixpanel/client.rb
+++ b/lib/mixpanel/client.rb
@@ -91,11 +91,12 @@ module Mixpanel
     #
     # @return [Hash] collection of options including defaults and generated signature
     def normalize_options(options)
-      options.merge!(
+      normalized_options = options.dup
+      normalized_options.merge!(
         :format  => @format,
         :api_key => @api_key,
         :expire  => Time.now.to_i + 600 # Grant this request 10 minutes
-      ).merge!(:sig => Utils.generate_signature(options, @api_secret))
+      ).merge!(:sig => Utils.generate_signature(normalized_options, @api_secret))
     end
 
     def self.base_uri_for_resource(resource)

--- a/spec/mixpanel_client/mixpanel_client_spec.rb
+++ b/spec/mixpanel_client/mixpanel_client_spec.rb
@@ -59,6 +59,16 @@ describe Mixpanel::Client do
       data.should == {"events"=>[], "type"=>"general"}
     end
 
+    it 'does not modify the provided options' do
+      options = { foo: 'bar' }
+      # Stub Mixpanel request
+      stub_request(:get, /^#{@uri}.*/).to_return(:body => '{"events": [], "type": "general"}')
+      expect {
+        @client.request('events/top', options)
+      }.to_not change { options }
+    end
+
+
     context "with parallel option enabled" do
       before :all do
         @parallel_client = Mixpanel::Client.new(:api_key => 'test_key', :api_secret => 'test_secret', :parallel => true)


### PR DESCRIPTION
Overriding it can cause unexpecting errors in continuous requests.
