### PR TITLE
Add raw response format

### DIFF
--- a/lib/mixpanel/client.rb
+++ b/lib/mixpanel/client.rb
@@ -65,7 +65,7 @@ module Mixpanel
     def make_normal_request(resource)
       response = URI.get(@uri)
 
-      if %w(export import).include?(resource)
+      if %w(export import).include?(resource) && @format != 'raw'
         response = %Q([#{response.split("\n").join(',')}])
       end
 

--- a/lib/mixpanel/utils.rb
+++ b/lib/mixpanel/utils.rb
@@ -34,7 +34,7 @@ module Mixpanel
       # @param [String] data either CSV or JSON formatted
       # @return [JSON, String] data
       def self.to_hash(data, format)
-        if format == 'csv'
+        if format == 'csv' || format == 'raw'
           data
         else
           begin


### PR DESCRIPTION
I particularly needed to add this for the export api. The ec2 instance I was using was running out of memory.
