### PR TITLE
Make request options optional

### DIFF
--- a/lib/mixpanel/client.rb
+++ b/lib/mixpanel/client.rb
@@ -91,7 +91,7 @@ module Mixpanel
     # @options  [Hash] options variables used to make a specific request for
     #           mixpanel data
     # @return   [JSON, String] mixpanel response as a JSON object or CSV string
-    def request_uri(resource, options)
+    def request_uri(resource, options = {} )
       @format = options[:format] || :json
       URI.mixpanel(resource, normalize_options(options))
     end


### PR DESCRIPTION
Method: list 
This method takes no parameters.
But request method require options arg, so i need to pass an empty hash
@mixpanel_client.request('funnels/list', {} )
Probably if we have method which takes no parameters, options should be optional
@mixpanel_client.request('funnels/list' )
