### PR TITLE
Verbose configuration for client

### DIFF
--- a/lib/mixpanel/client.rb
+++ b/lib/mixpanel/client.rb
@@ -27,6 +27,7 @@ module Mixpanel
       @api_key    = config[:api_key]
       @api_secret = config[:api_secret]
       @parallel   = config[:parallel]   || false
+      @verbose = config[:verbose] || false
 
       fail ConfigurationError if @api_key.nil? || @api_secret.nil?
     end
@@ -93,7 +94,7 @@ module Mixpanel
     # @return   [JSON, String] mixpanel response as a JSON object or CSV string
     def request_uri(resource, options = {} )
       @format = options[:format] || :json
-      URI.mixpanel(resource, normalize_options(options))
+      URI.mixpanel(resource, normalize_options(options), @verbose)
     end
 
     # rubocop:disable MethodLength

--- a/lib/mixpanel/uri.rb
+++ b/lib/mixpanel/uri.rb
@@ -9,9 +9,11 @@
 module Mixpanel
   # Utilities to assist generating and requesting URIs
   class URI
-    def self.mixpanel(resource, params)
+    def self.mixpanel(resource, params, verbose=false)
       base = Mixpanel::Client.base_uri_for_resource(resource)
-      "#{File.join([base, resource.to_s])}?#{encode(params)}"
+      uri = "#{File.join([base, resource.to_s])}?#{encode(params)}"
+      puts uri if verbose
+      return uri
     end
 
     def self.encode(params)


### PR DESCRIPTION
Sometimes you need to view the generated Mixpanel API url. So I added a verbose option for the client.
