### PR TITLE
Add timeout option

### DIFF
--- a/lib/mixpanel/client.rb
+++ b/lib/mixpanel/client.rb
@@ -14,7 +14,7 @@ module Mixpanel
     IMPORT_URI = 'https://api.mixpanel.com'
 
     attr_reader   :uri
-    attr_accessor :api_key, :api_secret, :parallel
+    attr_accessor :api_key, :api_secret, :parallel, :timeout
 
     # Configure the client
     #
@@ -27,6 +27,7 @@ module Mixpanel
       @api_key    = config[:api_key]
       @api_secret = config[:api_secret]
       @parallel   = config[:parallel]   || false
+      @timeout    = config[:timeout]    || nil
 
       fail ConfigurationError if @api_key.nil? || @api_secret.nil?
     end
@@ -63,7 +64,7 @@ module Mixpanel
     end
 
     def make_normal_request(resource)
-      response = URI.get(@uri)
+      response = URI.get(@uri, @timeout)
 
       if %w(export import).include?(resource) && @format != 'raw'
         response = %Q([#{response.split("\n").join(',')}])

--- a/lib/mixpanel/uri.rb
+++ b/lib/mixpanel/uri.rb
@@ -18,8 +18,8 @@ module Mixpanel
       params.map { |key, val| "#{key}=#{CGI.escape(val.to_s)}" }.sort.join('&')
     end
 
-    def self.get(uri)
-      ::URI.parse(uri).read
+    def self.get(uri, timeout)
+      ::URI.parse(uri).read(read_timeout: timeout)
     rescue OpenURI::HTTPError => error
       raise HTTPError, JSON.parse(error.io.read)['error']
     end

--- a/spec/mixpanel_client/mixpanel_client_spec.rb
+++ b/spec/mixpanel_client/mixpanel_client_spec.rb
@@ -25,6 +25,21 @@ describe Mixpanel::Client do
         parallel: true
       ).parallel.should eq true
     end
+
+    it 'should set a timeout option as nil by default' do
+      Mixpanel::Client.new(
+        api_key: 'test_key',
+        api_secret: 'test_secret'
+      ).timeout.should be_nil
+    end
+
+    it 'should be able to set a timeout option when passed' do
+      Mixpanel::Client.new(
+        api_key: 'test_key',
+        api_secret: 'test_secret',
+        timeout: 3
+      ).timeout.should eql 3
+    end
   end
 
   context 'when making an invalid request' do

--- a/spec/mixpanel_client/uri_spec.rb
+++ b/spec/mixpanel_client/uri_spec.rb
@@ -53,7 +53,29 @@ describe Mixpanel::URI do
     it 'should return a string response' do
       stub_request(:get, 'http://example.com').to_return(body: 'something')
 
-      Mixpanel::URI.get('http://example.com').should eq 'something'
+      Mixpanel::URI.get('http://example.com', nil).should eq 'something'
+    end
+
+    context 'when timeout is not nil' do
+
+      context 'when the request times out' do
+        it 'should return a timeout error' do
+          stub_request(:get, 'http://example.com').to_timeout
+
+          expect do
+            Mixpanel::URI.get('http://example.com', 3)
+          end.to raise_error Timeout::Error
+        end
+      end
+
+      context 'when the request does not timeout' do
+        it 'should return a string response' do
+          stub_request(:get, 'http://example.com').to_return(body: 'something')
+
+          Mixpanel::URI.get('http://example.com', 3).should eq 'something'
+        end
+      end
+
     end
   end
 end


### PR DESCRIPTION
Hey @keolo,

We've been experiencing mixpanel API timing out a lot recently, so we added a timeout option to reduce page load when mixpanel is timing out.

When you setup mixpanel, you can specify a timeout in seconds. If you don't specify anything, the timeout will be set to nil, which OpenURI takes as having no timeout (what it does currently).