### PR TITLE
change authentication method to fix #52

### DIFF
--- a/config/mixpanel.template.yml
+++ b/config/mixpanel.template.yml
@@ -1,3 +1,3 @@
 mixpanel:
-  api_key:    'changeme'
-  api_secret: 'changeme'
+  :api_key:    'changeme'
+  :api_secret: 'changeme'

--- a/lib/mixpanel/client.rb
+++ b/lib/mixpanel/client.rb
@@ -64,7 +64,7 @@ module Mixpanel
     end
 
     def make_normal_request(resource)
-      response = URI.get(@uri, @timeout)
+      response = URI.get(@uri, @timeout, @api_secret)
 
       if %w(export import).include?(resource) && @format != 'raw'
         response = %([#{response.split("\n").join(',')}])
@@ -99,7 +99,7 @@ module Mixpanel
 
     # rubocop:disable MethodLength
     def prepare_parallel_request
-      request = ::Typhoeus::Request.new(@uri)
+      request = ::Typhoeus::Request.new(@uri, userpwd: "#{@api_secret}:")
 
       request.on_complete do |response|
         if response.success?
@@ -145,11 +145,7 @@ module Mixpanel
       normalized_options
         .merge!(
           format:  @format,
-          api_key: @api_key,
           expire:  request_expires_at(normalized_options)
-        )
-        .merge!(
-          sig: Utils.generate_signature(normalized_options, @api_secret)
         )
     end
 

--- a/lib/mixpanel/uri.rb
+++ b/lib/mixpanel/uri.rb
@@ -18,8 +18,8 @@ module Mixpanel
       params.map { |key, val| "#{key}=#{CGI.escape(val.to_s)}" }.sort.join('&')
     end
 
-    def self.get(uri, timeout)
-      ::URI.parse(uri).read(read_timeout: timeout)
+    def self.get(uri, timeout, secret)
+      ::URI.parse(uri).read(read_timeout: timeout, http_basic_authentication: [secret, nil])
     rescue OpenURI::HTTPError => error
       raise HTTPError, JSON.parse(error.io.read)['error']
     end

--- a/spec/mixpanel_client/uri_spec.rb
+++ b/spec/mixpanel_client/uri_spec.rb
@@ -57,7 +57,7 @@ describe Mixpanel::URI do
     it 'should return a string response' do
       stub_request(:get, 'http://example.com').to_return(body: 'something')
 
-      Mixpanel::URI.get('http://example.com', nil).should eq 'something'
+      Mixpanel::URI.get('http://example.com', nil, 'secret').should eq 'something'
     end
 
     context 'when timeout is not nil' do
@@ -66,7 +66,7 @@ describe Mixpanel::URI do
           stub_request(:get, 'http://example.com').to_timeout
 
           expect do
-            Mixpanel::URI.get('http://example.com', 3)
+            Mixpanel::URI.get('http://example.com', 3, 'secret')
           end.to raise_error Timeout::Error
         end
       end
@@ -75,7 +75,7 @@ describe Mixpanel::URI do
         it 'should return a string response' do
           stub_request(:get, 'http://example.com').to_return(body: 'something')
 
-          Mixpanel::URI.get('http://example.com', 3).should eq 'something'
+          Mixpanel::URI.get('http://example.com', 3, 'secret').should eq 'something'
         end
       end
     end


### PR DESCRIPTION
Fixes #52 

See the authentication section here: https://mixpanel.com/help/reference/data-export-api

Looks like MixPanel have disabled the old authentication for the data export api some time in the last 24 hours