### PR TITLE
Remove deprecated authentication options

### DIFF
--- a/config/mixpanel.template.yml
+++ b/config/mixpanel.template.yml
@@ -1,3 +1,2 @@
 mixpanel:
-  :api_key:    'changeme'
   :api_secret: 'changeme'

--- a/lib/mixpanel/client.rb
+++ b/lib/mixpanel/client.rb
@@ -14,7 +14,7 @@ module Mixpanel
     IMPORT_URI = 'https://api.mixpanel.com'.freeze
 
     attr_reader :uri
-    attr_accessor :api_key, :api_secret, :parallel, :timeout
+    attr_accessor :api_secret, :parallel, :timeout
 
     def self.base_uri_for_resource(resource)
       if resource == 'export'
@@ -29,17 +29,16 @@ module Mixpanel
     # Configure the client
     #
     # @example
-    #   config = {api_key: '123', api_secret: '456'}
+    #   config = {api_secret: '456'}
     #   client = Mixpanel::Client.new(config)
     #
-    # @param [Hash] config consisting of an 'api_key' and an 'api_secret'
+    # @param [Hash] config consisting of an 'api_secret' and additonal options
     def initialize(config)
-      @api_key    = config[:api_key]
       @api_secret = config[:api_secret]
       @parallel   = config[:parallel] || false
       @timeout    = config[:timeout] || nil
 
-      raise ConfigurationError if @api_key.nil? || @api_secret.nil?
+      raise ConfigurationError, 'api_secret is required' if @api_secret.nil?
     end
 
     # Return mixpanel data as a JSON object or CSV string
@@ -152,17 +151,7 @@ module Mixpanel
     #         signature
     def normalize_options(options)
       normalized_options = options.dup
-
-      normalized_options
-        .merge!(
-          format:  @format,
-          expire:  request_expires_at(normalized_options)
-        )
-    end
-
-    def request_expires_at(options)
-      ten_minutes_from_now = Time.now.to_i + 600
-      options[:expire] ? options[:expire].to_i : ten_minutes_from_now
+      normalized_options.merge!(format: @format)
     end
   end
 end

--- a/manual_test/basic.rb
+++ b/manual_test/basic.rb
@@ -12,7 +12,6 @@ config = YAML.load_file(File.join(
 ))['mixpanel']
 
 client = Mixpanel::Client.new(
-  api_key: config[:api_key],
   api_secret: config[:api_secret]
 )
 

--- a/manual_test/parallel.rb
+++ b/manual_test/parallel.rb
@@ -15,7 +15,6 @@ config = YAML.load_file(
 )['mixpanel']
 
 client = Mixpanel::Client.new(
-  api_key:    config[:api_key],
   api_secret: config[:api_secret],
   parallel:   true
 )

--- a/readme.md
+++ b/readme.md
@@ -22,7 +22,6 @@ or if you use a Gemfile
     require 'mixpanel_client'
 
     client = Mixpanel::Client.new(
-      api_key:    'changeme',
       api_secret: 'changeme'
     )
 
@@ -69,7 +68,6 @@ You may also make requests in parallel by passing in the `parallel: true` option
     require 'mixpanel_client'
 
     client = Mixpanel::Client.new(
-      api_key:    'changeme',
       api_secret: 'changeme',
       parallel:   true
     )

--- a/spec/mixpanel_client/mixpanel_client_spec.rb
+++ b/spec/mixpanel_client/mixpanel_client_spec.rb
@@ -3,7 +3,6 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe Mixpanel::Client do
   before :all do
     @client = Mixpanel::Client.new(
-      api_key: 'test_key',
       api_secret: 'test_secret'
     )
 
@@ -13,14 +12,12 @@ describe Mixpanel::Client do
   context 'when initializing a new Mixpanel::Client' do
     it 'should set a parallel option as false by default' do
       expect(Mixpanel::Client.new(
-        api_key: 'test_key',
         api_secret: 'test_secret'
       ).parallel).to eq(false)
     end
 
     it 'should be able to set a parallel option when passed' do
       expect(Mixpanel::Client.new(
-        api_key: 'test_key',
         api_secret: 'test_secret',
         parallel: true
       ).parallel).to eq(true)
@@ -28,14 +25,12 @@ describe Mixpanel::Client do
 
     it 'should set a timeout option as nil by default' do
       expect(Mixpanel::Client.new(
-        api_key: 'test_key',
         api_secret: 'test_secret'
       ).timeout).to be_nil
     end
 
     it 'should be able to set a timeout option when passed' do
       expect(Mixpanel::Client.new(
-        api_key: 'test_key',
         api_secret: 'test_secret',
         timeout: 3
       ).timeout).to eql(3)
@@ -43,19 +38,9 @@ describe Mixpanel::Client do
   end
 
   context 'when making an invalid request' do
-    it 'should raise an error when API key is null' do
-      expect do
-        Mixpanel::Client.new(
-          api_key:    nil,
-          api_secret: 'test_secret'
-        )
-      end.to raise_error
-    end
-
     it 'should raise an error when API secret is null' do
       expect do
         Mixpanel::Client.new(
-          api_key:    'test_key',
           api_secret: nil
         )
       end.to raise_error
@@ -154,52 +139,9 @@ describe Mixpanel::Client do
       end.to_not change { options }
     end
 
-    context 'with a custom expiry time' do
-      # Stub Mixpanel request
-      before do
-        stub_request(:get, /^#{@uri}.*/)
-          .to_return(
-            body: '{"events": [], "type": "general"}'
-          )
-      end
-
-      let(:expiry)   { Time.now + 100_000 }
-      let(:fake_url) { Mixpanel::Client::BASE_URI }
-
-      specify 'Client#request should return a hash with empty events and
-               type' do
-        # With endpoint
-        data = @client.request(
-          'events/top',
-          type: 'general',
-          expire: expiry
-        )
-
-        data.should eq(
-          'events' => [],
-          'type'   => 'general'
-        )
-      end
-
-      specify 'Mixpanel::URI instance should receive the custom expiry time in
-               the options[:expiry] instead of 600s' do
-        expect(Mixpanel::URI).to receive(:mixpanel) do |*args|
-          args.pop[:expire].should eq expiry.to_i
-          true
-        end.and_return(fake_url)
-
-        @client.request(
-          'events/top',
-          type: 'general',
-          expire: expiry
-        )
-      end
-    end
-
     context 'with parallel option enabled' do
       before :all do
         @parallel_client = Mixpanel::Client.new(
-          api_key: 'test_key',
           api_secret: 'test_secret',
           parallel: true
         )

--- a/spec/mixpanel_client/mixpanel_client_spec.rb
+++ b/spec/mixpanel_client/mixpanel_client_spec.rb
@@ -43,7 +43,7 @@ describe Mixpanel::Client do
         Mixpanel::Client.new(
           api_secret: nil
         )
-      end.to raise_error
+      end.to raise_error(Mixpanel::ConfigurationError)
     end
 
     it 'should return an argument error "Wrong number of arguments" if using
@@ -167,7 +167,7 @@ describe Mixpanel::Client do
 
       describe '#hydra' do
         it 'should return a Typhoeus::Hydra object' do
-          @parallel_client.hydra.should be_a Typhoeus::Hydra
+          expect(@parallel_client.hydra).to be_a Typhoeus::Hydra
         end
       end
 
@@ -224,7 +224,7 @@ describe Mixpanel::Client do
 
           @parallel_client.run_parallel_requests
 
-          first_request.response.handled_response.should eq(
+          expect(first_request.response.handled_response).to eq(
             'data' => {
               'series' => %w(2010-05-29 2010-05-30 2010-05-31),
               'values' => {
@@ -241,7 +241,7 @@ describe Mixpanel::Client do
             'legend_size' => 1
           )
 
-          second_request.response.handled_response.should eq(
+          expect(second_request.response.handled_response).to eq(
             'data' => {
               'series' => %w(2010-05-29 2010-05-30 2010-05-31),
               'values' => {
@@ -277,7 +277,7 @@ describe Mixpanel::Client do
         @client.api_secret
       )
 
-      unsorted_signature.should eq sorted_signature
+      expect(unsorted_signature).to eq sorted_signature
     end
   end
 

--- a/spec/mixpanel_client/properties_externalspec.rb
+++ b/spec/mixpanel_client/properties_externalspec.rb
@@ -12,7 +12,7 @@ describe 'External calls to mixpanel' do
                               'mixpanel.yml'
     ))['mixpanel']
 
-    config.should_not be_nil
+    expect(config).not_to be_nil
     @client = Mixpanel::Client.new(config)
   end
 
@@ -21,7 +21,7 @@ describe 'External calls to mixpanel' do
       data = lambda do
         @client.request('properties', {})
       end
-      data.should raise_error(Mixpanel::HTTPError)
+      expect(data).to raise_error(Mixpanel::HTTPError)
     end
 
     it 'should return events' do
@@ -34,7 +34,7 @@ describe 'External calls to mixpanel' do
                              interval: 24,
                              limit: 5,
                              bucket: 'kicked')
-      data.should_not be_a Exception
+      expect(data().not_to be_a Exception
     end
   end
 end


### PR DESCRIPTION
The `api_key` and `expire` options seem to have been used by the deprecated authentication (see https://mixpanel.com/help/reference/data-export-api#authentication), but were not completely removed from this gem.

Additionally `api_key` is currently required for the gem to work, but is not actually used anywhere in the codebase.

Also added a commit that fixes some rspec warnings and deprecations, they really bugged me when running the test suite locally 😄 