### PR TITLE
Remove unused generate_signature helper method

### DIFF
--- a/lib/mixpanel/utils.rb
+++ b/lib/mixpanel/utils.rb
@@ -16,19 +16,6 @@ module Mixpanel
     # Copyright (c) 2009+ Keolo Keagy
     # See LICENSE for details
     module Utils
-      # Return a string composed of hashed values specified by the mixpanel
-      # data API
-      #
-      # @return [String] md5 hash signature required by mixpanel data API
-      def self.generate_signature(args, api_secret)
-        Digest::MD5.hexdigest(
-          args.map { |key, val| "#{key}=#{val}" }
-          .sort
-          .join +
-          api_secret
-        )
-      end
-
       # Return a JSON object or a string depending on a given format
       #
       # @param [String] data either CSV or JSON formatted

--- a/spec/mixpanel_client/mixpanel_client_spec.rb
+++ b/spec/mixpanel_client/mixpanel_client_spec.rb
@@ -262,25 +262,6 @@ describe Mixpanel::Client do
     end
   end
 
-  describe '#hash_args' do
-    it 'should return a hashed string alpha sorted by key names.' do
-      args              = { c: 'see', a: 'ey', d: 'dee', b: 'bee' }
-      args_alpha_sorted = { a: 'ey', b: 'bee', c: 'see', d: 'dee' }
-
-      unsorted_signature = Mixpanel::Client::Utils.generate_signature(
-        args,
-        @client.api_secret
-      )
-
-      sorted_signature = Mixpanel::Client::Utils.generate_signature(
-        args_alpha_sorted,
-        @client.api_secret
-      )
-
-      expect(unsorted_signature).to eq sorted_signature
-    end
-  end
-
   describe '#to_hash' do
     it 'should return a ruby hash given json as a string' do
       expect(Mixpanel::Client::Utils.to_hash(


### PR DESCRIPTION
Found this while looking through the codebase for https://github.com/keolo/mixpanel_client/issues/58, looks like another part of the old authentication code.