### PR TITLE
Allow overriding the API URIs

### DIFF
--- a/lib/mixpanel/client.rb
+++ b/lib/mixpanel/client.rb
@@ -18,11 +18,11 @@ module Mixpanel
 
     def self.base_uri_for_resource(resource)
       if resource == 'export'
-        DATA_URI
+        @@data_uri ? @@data_uri : DATA_URI
       elsif resource == 'import'
-        IMPORT_URI
+        @@import_uri ? @@import_uri : IMPORT_URI
       else
-        BASE_URI
+        @@base_uri ? @@base_uri : BASE_URI
       end
     end
 
@@ -37,6 +37,9 @@ module Mixpanel
       @api_secret = config[:api_secret]
       @parallel   = config[:parallel] || false
       @timeout    = config[:timeout] || nil
+      @@base_uri   = config[:base_uri] || nil
+      @@data_uri   = config[:data_uri] || nil
+      @@import_uri   = config[:import_uri] || nil
 
       raise ConfigurationError, 'api_secret is required' if @api_secret.nil?
     end


### PR DESCRIPTION
The Mixpanel support team have asked me to use the new "beta" version of the API to resolve some performance issues. However, since the base API URIs are coded in string literals, it's not possible to use an alternate URI. I've created this branch to allow you to override any of the three API URIs by passing them as part of the `config` parameters when creating a new instance.