### PR TITLE
Support service accounts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 
 # Specify your gem's dependencies in mixpanel_client.gemspec
 gemspec

--- a/lib/mixpanel/client.rb
+++ b/lib/mixpanel/client.rb
@@ -14,7 +14,7 @@ module Mixpanel
     IMPORT_URI = 'https://api.mixpanel.com'.freeze
 
     attr_reader :uri
-    attr_accessor :api_secret, :timeout
+    attr_accessor :auth, :timeout
 
     def self.base_uri_for_resource(resource)
       if resource == 'export'
@@ -27,20 +27,22 @@ module Mixpanel
     end
 
     # Configure the client
+    # The config must have the auth field, which is a list of
+    # either [api_secret, nil] or [service_account_username, service_account_pass].
     #
     # @example
-    #   config = {api_secret: '456'}
+    #   config = {auth: ['some-api-secret', nil]}
     #   client = Mixpanel::Client.new(config)
     #
-    # @param [Hash] config consisting of an 'api_secret' and additonal options
+    # @param [Hash] config consisting of the auth data & any additional options.
     def initialize(config)
-      @api_secret  = config[:api_secret]
+      @auth        = config[:auth]
       @timeout     = config[:timeout]    || nil
       @@base_uri   = config[:base_uri]   || nil
       @@data_uri   = config[:data_uri]   || nil
       @@import_uri = config[:import_uri] || nil
 
-      raise ConfigurationError, 'api_secret is required' if @api_secret.nil?
+      raise ConfigurationError, 'auth details are required' if @auth.nil?
     end
 
     # Return mixpanel data as a JSON object or CSV string
@@ -65,7 +67,7 @@ module Mixpanel
     def request(resource, options)
       @uri = request_uri(resource, options)
 
-      response = URI.get(@uri, @timeout, @api_secret)
+      response = URI.get(@uri, @timeout, @auth)
 
       if %w(export import).include?(resource) && @format != 'raw'
         response = %([#{response.split("\n").join(',')}])

--- a/lib/mixpanel/uri.rb
+++ b/lib/mixpanel/uri.rb
@@ -18,10 +18,10 @@ module Mixpanel
       params.map { |key, val| "#{key}=#{CGI.escape(val.to_s)}" }.sort.join('&')
     end
 
-    def self.get(uri, timeout, secret)
+    def self.get(uri, timeout, auth)
       ::URI.parse(uri).read(
         read_timeout: timeout,
-        http_basic_authentication: [secret, nil]
+        http_basic_authentication: auth
       )
     rescue OpenURI::HTTPError => error
       raise HTTPError, JSON.parse(error.io.read)['error']

--- a/manual_test/basic.rb
+++ b/manual_test/basic.rb
@@ -12,7 +12,7 @@ config = YAML.load_file(File.join(
 ))['mixpanel']
 
 client = Mixpanel::Client.new(
-  api_secret: config[:api_secret]
+  auth: config[:auth]
 )
 
 data = client.request('events/properties',

--- a/spec/mixpanel_client/mixpanel_client_spec.rb
+++ b/spec/mixpanel_client/mixpanel_client_spec.rb
@@ -3,7 +3,7 @@ require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 describe Mixpanel::Client do
   before :all do
     @client = Mixpanel::Client.new(
-      api_secret: 'test_secret'
+      auth: ['test_secret', nil]
     )
 
     @uri = Regexp.escape(Mixpanel::Client::BASE_URI)
@@ -12,23 +12,23 @@ describe Mixpanel::Client do
   context 'when initializing a new Mixpanel::Client' do
     it 'should set a timeout option as nil by default' do
       expect(Mixpanel::Client.new(
-        api_secret: 'test_secret'
+        auth: ['test_secret', nil]
       ).timeout).to be_nil
     end
 
     it 'should be able to set a timeout option when passed' do
       expect(Mixpanel::Client.new(
-        api_secret: 'test_secret',
+        auth: ['test_secret', nil],
         timeout: 3
       ).timeout).to eql(3)
     end
   end
 
   context 'when making an invalid request' do
-    it 'should raise an error when API secret is null' do
+    it 'should raise an error when auth is null' do
       expect do
         Mixpanel::Client.new(
-          api_secret: nil
+          auth: nil
         )
       end.to raise_error(Mixpanel::ConfigurationError)
     end


### PR DESCRIPTION
Adding support for [Service Accounts](https://developer.mixpanel.com/reference/service-accounts), since [Project Secrets](https://developer.mixpanel.com/reference/project-secret) are deprecated.

This is a breaking change, but if you have any suggestions as to how to handle this gracefully, I'm open to it! (Though since MP is deprecating it on their end, I suppose a more blunt breakage is inevitable.)